### PR TITLE
Monomorphic support for polymorphic case classes

### DIFF
--- a/src/test/scala/optics/poly/FocusTest.scala
+++ b/src/test/scala/optics/poly/FocusTest.scala
@@ -12,9 +12,13 @@ final class FocusTest extends munit.FunSuite {
   case class Animal(name: String)
   case class Owner(pet: Animal)
   case class Shop(owner: Owner)
-
-  val fooLens: EOptional[NoSuchElementException, Shop, String] =
-    Focus[Shop](_.owner.pet.name)
+  case class Box[A](a: A) 
+  case class MultiBox[A,B](a: A, b: B)
+  case class HigherBox[F[_], A](fa: F[A])
+  case class RefinedBox[A](a: A) {type Banana}
+  case class UnionBox[A,B](aOrB: A | B)
+  case class ConstraintBox[A <: AnyVal](a: A)
+  case class Varargs[A](a: A*)
 
   test("Single field access") {
     assertEquals(
@@ -30,7 +34,51 @@ final class FocusTest extends munit.FunSuite {
     )
   }
 
+  test("Type parameter field access") {
+    assertEquals(
+      Focus[Box[String]](_.a).getOrError(Box("Hello")),
+      Right("Hello")
+    )
+  }
+
+  test("Type parameter set field") {
+    assertEquals(
+      Focus[Box[Int]](_.a).replace(111)(Box(222)),
+      Box(111)
+    )
+  }
+
+  test("Nested type parameter set field") {
+    assertEquals(
+      Focus[Box[Box[String]]](_.a.a).replace("hello")(Box(Box("ok"))),
+      Box(Box("hello"))
+    )
+  }
+
+  test("Multiple type parameters get field") {
+    assertEquals(
+      Focus[MultiBox[Int, Boolean]](_.b).get(MultiBox(222, true)),
+      true
+    )
+  }
+
+  test("Multiple type parameters set field") {
+    assertEquals(
+      Focus[MultiBox[String, Int]](_.a).replace("abc")(MultiBox("whatevs",222)),
+      MultiBox("abc", 222)
+    )
+  }
+
   /*
+  // We can't support this yet, because we don't know how to replace the type variables inside the `fa` value.
+  test("Higher kinded type parameter get field") {
+    assertEquals(
+      Focus[HigherBox[Option, Int]](_.fa).get(HigherBox(Some(23))),
+      Some(23)
+    )
+  }*/
+
+/*
   val fooLens: EOptional[NoSuchElementException, Foo, Int] =
     Focus[Foo](_.bar.?.fub.bab)
 


### PR DESCRIPTION
This PR allows Focus to get and replace on case classes with type parameters, like `case class Box[A](a: A)`, with two constraints, which will require more work to overcome:
1. The type parameter cannot change during update
2. It cannot yet support nested type parameters like `case class HigherBox[F[_], A](fa: F[A])`

However, the work done so far represents concrete self-contained progress, and I would like this PR to close #11; we can track the first constraint in #28, and I will open up another issue for the second constraint.

It required the following changes:
- Adding a `TypeInfo` class that makes it easier to track all the information we want to live in every `FocusAction`, and to add more information in the future.
- Using `TypeInfo` to track information about each case class's type parameters for every `FocusAction`.
- Swapping out the raw type parameters (eg `Box.this.A`) in that information with the actual known types supplied in the implementation (eg `scala.Predef.String`)
- Plugging this list of types into the call to `Select.overloaded`
- Beefing up the tests
- Removed `GenLens` and renamed the file to `Focus.scala`, so we can close #19 