### PR TITLE
Some feature, plus some refactoring

### DIFF
--- a/src/main/scala/optics/internal/focus/ErrorHandling.scala
+++ b/src/main/scala/optics/internal/focus/ErrorHandling.scala
@@ -7,7 +7,7 @@ private[focus] trait ErrorHandling {
     case FocusError.NotACaseClass(fromClass) => s"Expecting a case class in the 'From' position; found $fromClass"
     case FocusError.NotAConcreteClass(fromClass) => s"Expecting a concrete case class in the 'From' position; cannot reify type $fromClass"
     case FocusError.NotASimpleLambdaFunction => s"Expecting a lambda function that directly accesses a field. Example: `GenLens[Address](_.streetNumber)`"
-    case FocusError.DidNotDirectlyAccessArgument => s"Expecting a lambda function that directly accesses a field. Example: `GenLens[Address](_.streetNumber)`"
+    case FocusError.DidNotDirectlyAccessArgument(argName) => s"Expecting a lambda function that directly accesses the argument; other variable `$argName` found. Example: `GenLens[Address](_.streetNumber)`"
     case FocusError.ComposeMismatch(type1, type2) => s"Could not compose $type1 >>> $type2"
     case FocusError.UnexpectedCodeStructure(code) => s"Unexpected code structure: $code"
     case FocusError.CouldntFindFieldType(fromType, fieldName) => s"Couldn't find type for $fromType.$fieldName"

--- a/src/main/scala/optics/internal/focus/FocusBase.scala
+++ b/src/main/scala/optics/internal/focus/FocusBase.scala
@@ -9,34 +9,30 @@ private[focus] trait FocusBase {
   type Term = macroContext.reflect.Term
   type TypeRepr = macroContext.reflect.TypeRepr
 
-    // Common type information that we record about every action in the DSL
-  case class TypeInfo(from: TypeRepr, fromTypeArgs: List[TypeRepr], to: TypeRepr) {
-    override def toString(): String = 
-      s"TypeInfo(${from.show}, ${fromTypeArgs.map(_.show).mkString("[", ",", "]")}, ${to.show})"
-  }
-
   enum FocusAction {
-    case Field(name: String, typeInfo: TypeInfo)
-    //case Attempt(info: TypeInfo)
-    //case Index(i: Term, indexType: TypeRepr, info: TypeInfo)
-
-    def typeInfo: TypeInfo
+    case FieldSelect(name: String, fromType: TypeRepr, fromTypeArgs: List[TypeRepr], toType: TypeRepr)
+    case OptionSome(toType: TypeRepr)
 
     override def toString(): String = this match {
-      case Field(name, info) => s"Field($name, $info)"
+      case FieldSelect(name, fromType, fromTypeArgs, toType) => s"FieldSelect($name, ${fromType.show}, ${fromTypeArgs.map(_.show).mkString("[", ",", "]")}, ${toType.show})"
+      case OptionSome(toType) => s"OptionSome(${toType.show})"
     }
   }
 
   enum FocusError {
     case NotACaseClass(className: String)
     case NotAConcreteClass(className: String)
-    case DidNotDirectlyAccessArgument
+    case DidNotDirectlyAccessArgument(argName: String)
     case NotASimpleLambdaFunction
     case UnexpectedCodeStructure(code: String)
     case CouldntFindFieldType(fromType: String, fieldName: String)
     case ComposeMismatch(type1: String, type2: String)
 
     def asResult: FocusResult[Nothing] = Left(this)
+  }
+
+  trait FocusParser {
+    def unapply(term: Term): Option[FocusResult[(Term, FocusAction)]]
   }
 
   type FocusResult[+A] = Either[FocusError, A]

--- a/src/main/scala/optics/internal/focus/FocusImpl.scala
+++ b/src/main/scala/optics/internal/focus/FocusImpl.scala
@@ -11,7 +11,7 @@ private[focus] class FocusImpl(val macroContext: Quotes)
 
   import macroContext.reflect._
 
-  def run[From: Type, To: Type](lambda: Expr[From => To]): Expr[Lens[From, To]] = {
+  def run[From: Type, To: Type](lambda: Expr[From => To]): Expr[Any] = {
     val parseResult: FocusResult[List[FocusAction]] = 
       parseLambda[From](lambda.asTerm)
 
@@ -19,13 +19,13 @@ private[focus] class FocusImpl(val macroContext: Quotes)
       parseResult.flatMap(generateCode[From])
       
     generatedCode match {
-      case Right(code) => code.asExprOf[Lens[From,To]]
+      case Right(code) => code.asExpr
       case Left(error) => report.error(errorMessage(error)); '{???}
     }
   }
 }
 
 object FocusImpl {
-  def apply[From: Type, To: Type](lambda: Expr[From => To])(using Quotes): Expr[Lens[From, To]] =
+  def apply[From: Type, To: Type](lambda: Expr[From => To])(using Quotes): Expr[Any] =
     new FocusImpl(quotes).run(lambda)
 }

--- a/src/main/scala/optics/internal/focus/features/optionsome/OptionSomeGenerator.scala
+++ b/src/main/scala/optics/internal/focus/features/optionsome/OptionSomeGenerator.scala
@@ -1,0 +1,15 @@
+package optics.internal.focus.features.optionsome
+
+import optics.internal.focus.FocusBase
+
+private[focus] trait OptionSomeGenerator {
+  this: FocusBase => 
+
+  import macroContext.reflect._
+
+  def generateOptionSome(toType: TypeRepr): Term = {
+    toType.asType match {
+      case '[t] => '{ _root_.optics.poly.Prism.some[t] }.asTerm
+    }
+  }
+}

--- a/src/main/scala/optics/internal/focus/features/optionsome/OptionSomeParser.scala
+++ b/src/main/scala/optics/internal/focus/features/optionsome/OptionSomeParser.scala
@@ -1,0 +1,21 @@
+package optics.internal.focus.features.optionsome
+
+import optics.internal.focus.FocusBase
+
+private[focus] trait OptionSomeParser {
+  this: FocusBase => 
+
+  import macroContext.reflect._
+
+  object OptionSome extends FocusParser {
+
+    def unapply(term: Term): Option[FocusResult[(Term, FocusAction)]] = term match {
+      case Apply(TypeApply(Ident("some"), List(typeArg)), List(remainingCode)) => 
+        val toType = typeArg.tpe
+        val action = FocusAction.OptionSome(toType)
+        Some(Right(remainingCode, action))
+        
+      case _ => None
+    }
+  }
+}

--- a/src/main/scala/optics/poly/Focus.scala
+++ b/src/main/scala/optics/poly/Focus.scala
@@ -3,10 +3,15 @@ package optics.poly
 import optics.internal.focus.FocusImpl
 
 object Focus {
+
+  extension [A] (opt: Option[A])
+    def some: A = scala.sys.error("Extension method 'some' should only be used within the optics.poly.Focus macro.")
+
+
   def apply[S] = new MkFocus[S]
 
   class MkFocus[S] {
-    inline def apply[T](inline get: (S => T)): Lens[S,T] = 
+    transparent inline def apply[T](inline get: (S => T)): Any = 
       ${ FocusImpl('get) }
   }
 }

--- a/src/test/scala/optics/poly/focus/FocusFieldSelectTest.scala
+++ b/src/test/scala/optics/poly/focus/FocusFieldSelectTest.scala
@@ -1,6 +1,6 @@
 package optics.poly
 
-final class FocusTest extends munit.FunSuite {
+final class FocusFieldSelectTest extends munit.FunSuite {
 
   case class Fub(bab: Int)
   case class Bar(fub: Fub)
@@ -13,7 +13,7 @@ final class FocusTest extends munit.FunSuite {
   case class Box[A](a: A) 
   case class MultiBox[A,B](a: A, b: B)
   case class HigherBox[F[_], A](fa: F[A])
-  case class RefinedBox[A](a: A) {type Banana}
+  trait RefinedBox { type A; def a: A }
   case class UnionBox[A,B](aOrB: A | B)
   case class ConstraintBox[A <: AnyVal](a: A)
   case class Varargs[A](a: A*)
@@ -67,51 +67,18 @@ final class FocusTest extends munit.FunSuite {
     )
   }
 
-  /*
-  // We can't support this yet, because we don't know how to replace the type variables inside the `fa` value.
   test("Higher kinded type parameter get field") {
     assertEquals(
       Focus[HigherBox[Option, Int]](_.fa).get(HigherBox(Some(23))),
       Some(23)
     )
-  }*/
-
-/*
-  val fooLens: EOptional[NoSuchElementException, Foo, Int] =
-    Focus[Foo](_.bar.?.fub.bab)
-
-  test("compose focus with `?`") {
-    assertEquals(
-      fooLens.getOrError(Foo(Some(Bar(Fub(1))))),
-      Right(1)
-    )
   }
 
-  val quxLens: EOptional[NoSuchElementException | String, Qux, Int] =
-    Focus[Qux](_.foo.?.bar.?.fub.bab)
-
-  test("compose focus with nested `?`") {
+  /*
+  test("Refined type field accessss") {
     assertEquals(
-      quxLens.getOrError(Qux(Right(Foo(Some(Bar(Fub(1))))), Map())),
-      Right(1)
-    )
-  }
-
-
-  test("compose focus with index") {
-    val lens: EOptional[NoSuchElementException, Qux, Int] = Focus[Qux](_.moo.idx(32).bab)
-    assertEquals(
-      lens.getOrError(Qux(Left("moo"), Map(32 -> Fub(32)))),
-      Right(32)
-    )
-  }
-
-  test("mixture of operators") {
-    val lens = Focus[Map[String, Qux]](_.idx("moo").foo.?.bar.?.fub)
-    assertEquals(
-      lens.getOrError(Map("moo" -> Qux(Right(Foo(Some(Bar(Fub(21))))), Map()))),
-      Right(Fub(21))
+      Focus[RefinedBox { type A = String }](_.a).get(new RefinedBox { type A = String; def a = "Bob" }),
+      "Bob"
     )
   }*/
-
 }

--- a/src/test/scala/optics/poly/focus/FocusSomeTest.scala
+++ b/src/test/scala/optics/poly/focus/FocusSomeTest.scala
@@ -1,42 +1,55 @@
 package optics.poly.focus
 
+import optics.poly.Focus
+import optics.poly.Focus._
+
 final class FocusSomeTest extends munit.FunSuite {
 
-//  test("Access Option within a case class") {
-//    case class User(name: String, address: Option[Address])
-//    case class Address(streetNumber: Int, postcode: String)
-//
-//    val elise = User("Elise", Some(Address(12, "high street")))
-//    val bob   = User("bob"  , None)
-//
-//    val streetNumber = Focus[User](_.address.some.streetNumber)
-//
-//    assertEquals(streetNumber.getOption(elise), Some(12))
-//    assertEquals(streetNumber.getOption(bob), None)
-//  }
-//
-//  test("Access parametric Option within a case class") {
-//    case class IdOpt[A](id: Long, value: Option[A])
-//    case class User(name: String, age: Int)
-//
-//    val bob = User("bob", 24)
-//    val idSome = IdOpt(1, Some(bob))
-//    val idNone = IdOpt(1, None)
-//
-//    val age = Focus[IdOpt[User]](_.value.some.age)
-//
-//    assertEquals(age.getOption(idSome), Some(24))
-//    assertEquals(age.getOption(idNone), None)
-//  }
-//
-//  test("Access top level Option") {
-//    case class User(name: String, age: Int)
-//    val bob = User("bob", 24)
-//
-//    val age = Focus[Option[User]](_.some.age)
-//
-//    assertEquals(age.getOption(Some(bob)), Some(24))
-//    assertEquals(age.getOption(None), None)
-//  }
+  test("Access Option within a case class") {
+    case class User(name: String, address: Option[Address])
+    case class Address(streetNumber: Int, postcode: String)
 
+    val elise = User("Elise", Some(Address(12, "high street")))
+    val bob   = User("bob"  , None)
+
+    val streetNumber = Focus[User](_.address.some.streetNumber)
+
+    assertEquals(streetNumber.getOption(elise), Some(12))
+    assertEquals(streetNumber.getOption(bob), None)
+  }
+
+  test("Access parametric Option within a case class") {
+    case class IdOpt[+A](id: Long, value: Option[A])
+    case class User(name: String, age: Int)
+
+    val bob = User("bob", 24)
+    val idSome = IdOpt(1, Some(bob))
+    val idNone = IdOpt(1, None)
+
+    val age = Focus[IdOpt[User]](_.value.some.age)
+
+    assertEquals(age.getOption(idSome), Some(24))
+    assertEquals(age.getOption(idNone), None)
+  }
+
+  test("Access top level Option") {
+    case class User(name: String, age: Int)
+    val bob = User("bob", 24)
+
+    val age = Focus[Option[User]](_.some.age)
+
+    assertEquals(age.getOption(Some(bob)), Some(24))
+    assertEquals(age.getOption(None), None)
+  }
+
+  test("Access nested Option") {
+    case class User(name: String, age: Int)
+    val bob = User("Friedrich", 33)
+
+    val name = Focus[Option[Option[User]]](_.some.some.name)
+
+    assertEquals(name.getOption(Some(Some(bob))), Some("Friedrich"))
+    assertEquals(name.getOption(Some(None)), None)
+    assertEquals(name.getOption(None), None)
+  }
 }


### PR DESCRIPTION
Adds the `some` feature in the established pattern, with a parser & generator file in a new feature package, solving #17 

Of note:
- Fixes the restriction we had on selecting fields with nested type parameters, like `Option[A]` or `F[A]`.
- The macro signature is now `transparent inline`, which allows us to choose the static return type inside the macro. The declared return type is `Any`, which we can replace with a more civilised top type when the optics live inside the same type hierarchy.
- Extension method `some` available with a `Focus._` import, for want of a better scheme.
- Big refactor of `ParserLoop`, whose flaws were much more clearly visible with the addition of a second feature. 
- `ParserLoop` now knows nothing of the features and only performs iteration and assembly of the result. 
- Special treatment of the lambda argument has been separated from the feature matching.
- `FieldSelectParser` now only exposes one public member, the `FieldSelect` pattern matching parser.
- The `TypeInfo` type is deleted; it turned out to just be a `FieldSelect` thing, there was no need for this information in every `FocusAction`.
- The `composeOptics` method in `GeneratorLoop` now has a case for every combination of Lens, Optional, Prism and Iso.
- Brushed up the existing tests a bit to fit the pattern of Julien's test suite for `some` a bit better.