### PR TITLE
Applied focus support

### DIFF
--- a/src/main/scala/optics/internal/focus/AppliedFocusImpl.scala
+++ b/src/main/scala/optics/internal/focus/AppliedFocusImpl.scala
@@ -1,0 +1,20 @@
+package optics.internal.focus
+
+import optics.poly.{Focus, Lens, Iso, Prism, Optional}
+import scala.quoted.{Type, Expr, Quotes, quotes}
+
+
+object AppliedFocusImpl {
+  def apply[From: Type, To: Type](from: Expr[From], lambda: Expr[From => To])(using Quotes): Expr[Any] = {
+    import quotes.reflect._
+
+    val generatedOptic = new FocusImpl(quotes).run(lambda)
+
+    generatedOptic.asTerm.tpe.asType match {
+      case '[Lens[f, t]] => '{ _root_.optics.poly.Focus.AppliedLens[From, From, To, To]($from, ${generatedOptic.asExprOf[Lens[From,To]]}) }
+      case '[Prism[f, t]] => '{ _root_.optics.poly.Focus.AppliedPrism[From, From, To, To]($from, ${generatedOptic.asExprOf[Prism[From,To]]}) }
+      case '[Iso[f, t]] => '{ _root_.optics.poly.Focus.AppliedIso[From, From, To, To]($from, ${generatedOptic.asExprOf[Iso[From,To]]}) }
+      case '[Optional[f, t]] => '{ _root_.optics.poly.Focus.AppliedOptional[From, From, To, To]($from, ${generatedOptic.asExprOf[Optional[From,To]]}) }
+    }
+  }
+}

--- a/src/main/scala/optics/internal/focus/ErrorHandling.scala
+++ b/src/main/scala/optics/internal/focus/ErrorHandling.scala
@@ -6,8 +6,8 @@ private[focus] trait ErrorHandling {
   def errorMessage(error: FocusError): String = error match {
     case FocusError.NotACaseClass(fromClass) => s"Expecting a case class in the 'From' position; found $fromClass"
     case FocusError.NotAConcreteClass(fromClass) => s"Expecting a concrete case class in the 'From' position; cannot reify type $fromClass"
-    case FocusError.NotASimpleLambdaFunction => s"Expecting a lambda function that directly accesses a field. Example: `GenLens[Address](_.streetNumber)`"
-    case FocusError.DidNotDirectlyAccessArgument(argName) => s"Expecting a lambda function that directly accesses the argument; other variable `$argName` found. Example: `GenLens[Address](_.streetNumber)`"
+    case FocusError.NotASimpleLambdaFunction => s"Expecting a lambda function that directly accesses a field. Example: `Focus[Address](_.streetNumber)`"
+    case FocusError.DidNotDirectlyAccessArgument(argName) => s"Expecting a lambda function that directly accesses the argument; other variable `$argName` found. Example: `Focus[Address](_.streetNumber)`"
     case FocusError.ComposeMismatch(type1, type2) => s"Could not compose $type1 >>> $type2"
     case FocusError.UnexpectedCodeStructure(code) => s"Unexpected code structure: $code"
     case FocusError.CouldntFindFieldType(fromType, fieldName) => s"Couldn't find type for $fromType.$fieldName"

--- a/src/main/scala/optics/poly/Focus.scala
+++ b/src/main/scala/optics/poly/Focus.scala
@@ -1,17 +1,49 @@
 package optics.poly
 
-import optics.internal.focus.FocusImpl
+import optics.internal.focus.{FocusImpl, AppliedFocusImpl}
+import optics.internal.Applicative
 
 object Focus {
+
+  class AppliedLens[S, T, A, B](from: S, underlying: PLens[S, T, A, B]) {
+    def get: A = underlying.get(from)
+    def replace(to: B): T = underlying.replace(to)(from)
+    def modify(f: A => B): T = underlying.modify(f)(from)
+    export underlying.{some, adapt, andThen, asTraversal, asOptional}
+  }
+
+  class AppliedPrism[S, T, A, B](from: S, underlying: PPrism[S, T, A, B]) {
+    def getOrModify: Either[T, A] = underlying.getOrModify(from)
+    def getOption: Option[A] = underlying.getOption(from)
+    def replace(to: B): T = underlying.replace(to)(from)
+    export underlying.{reverseGet, andThen, asTraversal, asOptional}
+  }
+
+  class AppliedIso[S, T, A, B](from: S, underlying: PIso[S, T, A, B]) {
+    def get: A = underlying.get(from)
+    export underlying.{reverseGet, andThen, asTraversal, asOptional, asLens, asPrism}
+  }
+
+  class AppliedOptional[S, T, A, B](from: S, underlying: POptional[S, T, A, B]) {
+    def getOrModify: Either[T, A] = underlying.getOrModify(from)
+    def replace(to: B): T = underlying.replace(to)(from)
+    def modifyF[F[_] : Applicative](f: A => F[B]): F[T] = underlying.modifyF(f)(from)
+    def modify(f: A => B): T = underlying.modify(f)(from)
+    def getOption: Option[A] = underlying.getOption(from)
+    export underlying.{some, adapt, andThen, asTraversal}
+  }
+
+  extension [From, To] (from: From) 
+    transparent inline def focus(inline lambda: (From => To)): Any = 
+      ${AppliedFocusImpl[From, To]('from, 'lambda)}
 
   extension [A] (opt: Option[A])
     def some: A = scala.sys.error("Extension method 'some' should only be used within the optics.poly.Focus macro.")
 
+  def apply[From] = new MkFocus[From]
 
-  def apply[S] = new MkFocus[S]
-
-  class MkFocus[S] {
-    transparent inline def apply[T](inline get: (S => T)): Any = 
-      ${ FocusImpl('get) }
+  class MkFocus[From] {
+    transparent inline def apply[To](inline lambda: (From => To)): Any = 
+      ${ FocusImpl('lambda) }
   }
 }

--- a/src/test/scala/optics/poly/focus/AppliedFocusTest.scala
+++ b/src/test/scala/optics/poly/focus/AppliedFocusTest.scala
@@ -1,0 +1,33 @@
+package optics.poly.focus
+
+import optics.poly.Focus
+import optics.poly.Focus._
+
+final class AppliedFocusTest extends munit.FunSuite {
+
+  test("Applied focus returning an Optional") {
+    case class User(name: String, address: Option[Address])
+    case class Address(streetNumber: Int, postcode: String)
+
+    val elise = User("Elise", Some(Address(12, "high street")))
+
+    val streetNumber = elise.focus(_.address.some.streetNumber).getOption
+    val newElise = elise.focus(_.address.some.streetNumber).replace(50)
+
+    assertEquals(streetNumber, Some(12))
+    assertEquals(newElise, User("Elise", Some(Address(50, "high street"))))
+  }
+
+  test("Applied focus returning a Lens") {
+    case class User(name: String, address: Address)
+    case class Address(streetNumber: Int, postcode: String)
+
+    val bob = User("Bob", Address(5, "Bob St"))
+
+    val streetNumber = bob.focus(_.address.streetNumber).get
+    val newBob = bob.focus(_.address.streetNumber).replace(77)
+
+    assertEquals(streetNumber, 5)
+    assertEquals(newBob, User("Bob", Address(77, "Bob St")))
+  }
+}


### PR DESCRIPTION
Adds the applied syntax for Focus, resolving #24.

For the time being I've just added the `AppliedXXX` classes inside the `Focus` object; they seem to fit snugly.

I've ignored the problem of customising error messages, because we haven't given them any serious thought so far, so it is premature to do engineering towards supporting their current state.