### PR TITLE
Remove OpticCan constraint whenever possible

### DIFF
--- a/src/main/scala/monocly/OpticBuilder.scala
+++ b/src/main/scala/monocly/OpticBuilder.scala
@@ -4,8 +4,8 @@ import monocly.internal._
 import monocly.impl._
 
 object OpticsBuilder:
-  type OnlyHasSetter[Can <: OpticCan] = ReverseGet <:< Can
-  type OnlyHasGetter[Can <: OpticCan] = GetOne <:< Can
+  type OnlyHasSetter[Can] = ReverseGet <:< Can
+  type OnlyHasGetter[Can] = GetOne <:< Can
 
   extension [ThisCan <: Modify, S, T, A, B](optic: POptic[ThisCan, S, T, A, B])(using OnlyHasSetter[ThisCan])
     def withGetOne(_getOne: S => A): POptic[ThisCan & GetOne, S, T, A, B] = 

--- a/src/main/scala/monocly/OpticCan.scala
+++ b/src/main/scala/monocly/OpticCan.scala
@@ -1,0 +1,22 @@
+package monocly
+
+sealed trait OpticCan
+
+//        GetMany
+//          /\
+//         /  \
+// GetOption  GetOneOrMore
+//         \  /
+//          \/
+//        GetOne
+trait GetMany extends OpticCan
+trait GetOption extends GetMany
+trait GetOneOrMore extends GetMany
+trait GetOne extends GetOption with GetOneOrMore
+
+//    Modify
+//      ^
+//      |
+//  ReverseGet
+trait Modify extends OpticCan
+trait ReverseGet extends Modify

--- a/src/main/scala/monocly/impl/GetManyImpl.scala
+++ b/src/main/scala/monocly/impl/GetManyImpl.scala
@@ -33,7 +33,7 @@ trait GetManyImpl[+ThisCan <: GetMany, -S, +A] extends GetterImpl[ThisCan, S, A]
       override def _foldMap[M: Monoid](f: A => M): S0 => M = 
         s0 => self.foldMap(f)(impl1.get(s0))
 
-  override def andThen[ThatCan <: OpticCan, C](impl2: GetterImpl[ThatCan, A, C]): GetterImpl[ThisCan | ThatCan, S, C] = 
+  override def andThen[ThatCan, C](impl2: GetterImpl[ThatCan, A, C]): GetterImpl[ThisCan | ThatCan, S, C] =
     impl2.preComposeGetMany(this)
 
   override def foldMap[M](f: A => M)(using Monoid[M], ThisCan <:< GetMany): S => M = _foldMap(f)

--- a/src/main/scala/monocly/impl/GetOneImpl.scala
+++ b/src/main/scala/monocly/impl/GetOneImpl.scala
@@ -21,7 +21,7 @@ class GetOneImpl[+ThisCan <: GetOne, -S, +A](_get: S => A) extends GetterImpl[Th
   override def preComposeGetOne[ThatCan <: GetOne, S0](impl1: GetOneImpl[ThatCan, S0, S]): GetOneImpl[ThisCan | ThatCan, S0, A] = 
     GetOneImpl(s0 => get(impl1.get(s0)))
 
-  def andThen[ThatCan <: OpticCan, C](impl2: GetterImpl[ThatCan, A, C]): GetterImpl[ThisCan | ThatCan, S, C] = 
+  def andThen[ThatCan, C](impl2: GetterImpl[ThatCan, A, C]): GetterImpl[ThisCan | ThatCan, S, C] =
     impl2.preComposeGetOne(this)
 
   override def get(using ThisCan <:< GetOne): S => A = _get

--- a/src/main/scala/monocly/impl/GetOneOrMore.scala
+++ b/src/main/scala/monocly/impl/GetOneOrMore.scala
@@ -35,7 +35,7 @@ trait GetOneOrMoreImpl[+ThisCan <: GetOneOrMore, -S, +A] extends GetterImpl[This
       override def _foldMap1[M: Semigroup](f: A => M): S0 => M = 
         s0 => self.foldMap1(f)(impl1.get(s0))
 
-  override def andThen[ThatCan <: OpticCan, C](impl2: GetterImpl[ThatCan, A, C]): GetterImpl[ThisCan | ThatCan, S, C] = 
+  override def andThen[ThatCan, C](impl2: GetterImpl[ThatCan, A, C]): GetterImpl[ThisCan | ThatCan, S, C] =
     impl2.preComposeGetOneOrMore(this)
 
   override def foldMap1[M](f: A => M)(using Semigroup[M], ThisCan <:< GetOneOrMore): S => M = _foldMap1(f)

--- a/src/main/scala/monocly/impl/GetOptionImpl.scala
+++ b/src/main/scala/monocly/impl/GetOptionImpl.scala
@@ -22,7 +22,7 @@ class GetOptionImpl[+ThisCan <: GetOption, -S, +A](_getOption: S => Option[A]) e
   override def preComposeGetOne[ThatCan <: GetOne, S0](impl1: GetOneImpl[ThatCan, S0, S]): GetOptionImpl[ThisCan | ThatCan, S0, A] = 
     GetOptionImpl(s0 => impl1.getOption(s0).flatMap(getOption))
 
-  def andThen[ThatCan <: OpticCan, C](impl2: GetterImpl[ThatCan, A, C]): GetterImpl[ThisCan | ThatCan, S, C] = 
+  def andThen[ThatCan, C](impl2: GetterImpl[ThatCan, A, C]): GetterImpl[ThisCan | ThatCan, S, C] =
     impl2.preComposeGetOption(this)
 
   override def getOption(using ThisCan <:< GetOption): S => Option[A] = _getOption

--- a/src/main/scala/monocly/impl/GetterImpl.scala
+++ b/src/main/scala/monocly/impl/GetterImpl.scala
@@ -4,9 +4,9 @@ import monocly.internal._
 import monocly._
 
 
-trait GetterImpl[+ThisCan <: OpticCan, -S, +A]:
+trait GetterImpl[+ThisCan, -S, +A]:
 
-  def canAlso[NewCan <: OpticCan]: GetterImpl[NewCan, S, A] = 
+  def canAlso[NewCan <: OpticCan]: GetterImpl[NewCan, S, A] =
     asInstanceOf[GetterImpl[NewCan, S, A]]
 
   def preComposeGetMany[ThatCan <: GetMany, S0](impl1: GetManyImpl[ThatCan, S0, S]): GetterImpl[ThisCan | ThatCan, S0, A]
@@ -14,7 +14,7 @@ trait GetterImpl[+ThisCan <: OpticCan, -S, +A]:
   def preComposeGetOption[ThatCan <: GetOption, S0](impl1: GetOptionImpl[ThatCan, S0, S]): GetterImpl[ThisCan | ThatCan, S0, A]
   def preComposeGetOne[ThatCan <: GetOne, S0](impl1: GetOneImpl[ThatCan, S0, S]): GetterImpl[ThisCan | ThatCan, S0, A]
 
-  def andThen[ThatCan <: OpticCan, C](impl2: GetterImpl[ThatCan, A, C]): GetterImpl[ThisCan | ThatCan, S, C]
+  def andThen[ThatCan, C](impl2: GetterImpl[ThatCan, A, C]): GetterImpl[ThisCan | ThatCan, S, C]
 
   def get(using ThisCan <:< GetOne): S => A = sys.error("This optic does not support 'get'")
   def getOption(using ThisCan <:< GetOption): S => Option[A] = sys.error("This optic does not support 'getOption'")

--- a/src/main/scala/monocly/impl/ModifyImpl.scala
+++ b/src/main/scala/monocly/impl/ModifyImpl.scala
@@ -10,7 +10,7 @@ class ModifyImpl[ThisCan <: Modify, -S, +T, +A, -B](_modify: (A => B) => S => T)
   override def preComposeReverseGet[ThatCan <: ReverseGet, S0, T0](impl1: ReverseGetImpl[ThatCan, S0, T0, S, T]): ModifyImpl[ThisCan | ThatCan, S0, T0, A, B] = 
     ModifyImpl(f => s0 => impl1.modify(s => modify(f)(s))(s0))
 
-  override def andThen[ThatCan <: OpticCan, C, D](impl2: SetterImpl[ThatCan, A, B, C, D]): SetterImpl[ThisCan | ThatCan, S, T, C, D] = 
+  override def andThen[ThatCan, C, D](impl2: SetterImpl[ThatCan, A, B, C, D]): SetterImpl[ThisCan | ThatCan, S, T, C, D] =
     impl2.preComposeModify(this)
 
   override def modify(f: A => B)(using ThisCan <:< Modify): S => T = _modify(f)

--- a/src/main/scala/monocly/impl/NoGetter.scala
+++ b/src/main/scala/monocly/impl/NoGetter.scala
@@ -7,5 +7,5 @@ object NoGetter extends GetterImpl[Nothing, Any, Nothing]:
   override def preComposeGetOneOrMore[ThatCan <: GetOneOrMore, S0](impl1: GetOneOrMoreImpl[ThatCan, S0, Any]) = NoGetter
   override def preComposeGetOption[ThatCan <: GetOption, S0](impl1: GetOptionImpl[ThatCan, S0, Any]) = NoGetter
   override def preComposeGetOne[ThatCan <: GetOne, S0](impl1: GetOneImpl[ThatCan, S0, Any]) = NoGetter
-  override def andThen[ThatCan <: OpticCan, C](impl2: GetterImpl[ThatCan, Nothing, C]) = NoGetter
+  override def andThen[ThatCan, C](impl2: GetterImpl[ThatCan, Nothing, C]) = NoGetter
 end NoGetter

--- a/src/main/scala/monocly/impl/NoSetter.scala
+++ b/src/main/scala/monocly/impl/NoSetter.scala
@@ -5,5 +5,5 @@ import monocly._
 object NoSetter extends SetterImpl[Nothing, Any, Nothing, Nothing, Any]:
   override def preComposeModify[ThatCan <: Modify, S0, T0](impl1: ModifyImpl[ThatCan, S0, T0, Any, Nothing]) = NoSetter
   override def preComposeReverseGet[ThatCan <: ReverseGet, S0, T0](impl1: ReverseGetImpl[ThatCan, S0, T0, Any, Nothing]) = NoSetter
-  override def andThen[ThatCan <: OpticCan, C, D](impl2: SetterImpl[ThatCan, Nothing, Any, C, D]) = NoSetter
+  override def andThen[ThatCan, C, D](impl2: SetterImpl[ThatCan, Nothing, Any, C, D]) = NoSetter
 end NoSetter

--- a/src/main/scala/monocly/impl/ReverseGetImpl.scala
+++ b/src/main/scala/monocly/impl/ReverseGetImpl.scala
@@ -12,7 +12,7 @@ class ReverseGetImpl[ThisCan <: ReverseGet, -S, +T, +A, -B](_modify: (A => B) =>
       f => s0 => impl1.modify(s => modify(f)(s))(s0), 
       b => impl1.reverseGet(reverseGet(b)))
 
-  override def andThen[ThatCan <: OpticCan, C, D](impl2: SetterImpl[ThatCan, A, B, C, D]): SetterImpl[ThisCan | ThatCan, S, T, C, D] = 
+  override def andThen[ThatCan, C, D](impl2: SetterImpl[ThatCan, A, B, C, D]): SetterImpl[ThisCan | ThatCan, S, T, C, D] =
     impl2.preComposeReverseGet(this)
 
   override def modify(f: A => B)(using ThisCan <:< Modify): S => T = _modify(f)

--- a/src/main/scala/monocly/impl/SetterImpl.scala
+++ b/src/main/scala/monocly/impl/SetterImpl.scala
@@ -2,15 +2,15 @@ package monocly.impl
 
 import monocly._
 
-trait SetterImpl[+ThisCan <: OpticCan, -S, +T, +A, -B]:
+trait SetterImpl[+ThisCan, -S, +T, +A, -B]:
 
-  def canAlso[NewCan <: OpticCan]: SetterImpl[NewCan, S, T, A, B] = 
+  def canAlso[NewCan <: OpticCan]: SetterImpl[NewCan, S, T, A, B] =
     asInstanceOf[SetterImpl[NewCan, S, T, A, B]]
 
   def preComposeModify[ThatCan <: Modify, S0, T0](impl1: ModifyImpl[ThatCan, S0, T0, S, T]): SetterImpl[ThisCan | ThatCan, S0, T0, A, B]
   def preComposeReverseGet[ThatCan <: ReverseGet, S0, T0](impl1: ReverseGetImpl[ThatCan, S0, T0, S, T]): SetterImpl[ThisCan | ThatCan, S0, T0, A, B]
 
-  def andThen[ThatCan <: OpticCan, C, D](impl2: SetterImpl[ThatCan, A, B, C, D]): SetterImpl[ThisCan | ThatCan, S, T, C, D]
+  def andThen[ThatCan, C, D](impl2: SetterImpl[ThatCan, A, B, C, D]): SetterImpl[ThisCan | ThatCan, S, T, C, D]
 
   def modify(f: A => B)(using ThisCan <:< Modify): S => T = sys.error("This optic does not support 'modify'")
   def reverseGet(using ThisCan <:< ReverseGet): B => T = sys.error("This optic does not support 'replaceAll'")


### PR DESCRIPTION
PR to discuss the benefits of `<: OpticCan` constraint.