### PR TITLE
Split OpticCan into GetterCan and SetterCan

### DIFF
--- a/src/main/scala/monocly/Optic.scala
+++ b/src/main/scala/monocly/Optic.scala
@@ -4,63 +4,67 @@ import monocly.impl._
 import monocly.functions.{Each, Index}
 import monocly.internal.{NonEmptyList, Applicative, Monoid}
 
-type Optic[+ThisCan, S, A] = POptic[ThisCan, S, S, A, A]
+type Getter[+GetCan, S, A] = Optic[GetCan, Any, S, A]
+type Setter[+SetCan, S, A] = Optic[Any, SetCan, S, A]
+type PSetter[+SetCan, -S, +T, +A, -B] = POptic[Any, SetCan, S, T, A, B]
+type Optic[+GetCan, +SetCan, S, A] = POptic[GetCan, SetCan, S, S, A, A]
 
-final class POptic[+ThisCan, -S, +T, +A, -B] private[monocly](
-    protected[monocly] val getter: GetterImpl[ThisCan, S, A],
-    protected[monocly] val setter: SetterImpl[ThisCan, S, T, A, B]):
+final class POptic[+GetCan, +SetCan, -S, +T, +A, -B] private[monocly](
+    protected[monocly] val getter: GetterImpl[GetCan, S, A],
+    protected[monocly] val setter: SetterImpl[SetCan, S, T, A, B]):
 
-  def andThen[ThatCan, BothCan >: (ThisCan | ThatCan), C, D](o: POptic[ThatCan, A, B, C, D]): POptic[BothCan, S, T, C, D] =
+  def andThen[ThatGetCan >: GetCan, ThatSetCan >: SetCan, C, D](
+   o: POptic[ThatGetCan, ThatSetCan, A, B, C, D]
+  ): POptic[ThatGetCan, ThatSetCan, S, T, C, D] =
     POptic(getter.andThen(o.getter), setter.andThen(o.setter))
 
 end POptic
 
 
-extension [ThisCan, S, A] (optic: Optic[ThisCan, S, A])
-  def each[C](using evEach: Each[A, C]): Optic[ThisCan | (GetMany & Modify), S, C] = 
+extension [GetCan, SetCan, S, A] (optic: Optic[GetCan, SetCan, S, A])
+  def each[C](using evEach: Each[A, C]): Optic[GetCan | GetMany, SetCan | Modify, S, C] =
     optic.andThen(evEach.each)
 
-extension [S, T, A, B] (optic: POptic[GetMany, S, T, A, B])
-  inline def foldMap[M: Monoid](f: A => M)(s: S): M = ???
-
-extension [S, T, A, B] (optic: POptic[GetOne, S, T, A, B])
-  inline def get: S => A = optic.getter.get
-
-extension [S, T, A, B] (optic: POptic[GetMany, S, T, A, B])
-  inline def getAll: S => List[A] = optic.getter.foldMap[List[A]](List(_))
-
-extension [S, T, A, B] (optic: POptic[GetOneOrMore, S, T, A, B])
-  inline def getOneOrMore: S => NonEmptyList[A] = optic.getter.foldMap1[NonEmptyList[A]](NonEmptyList(_, Nil))
-
-extension [S, T, A, B] (optic: POptic[GetOption, S, T, A, B])
-  inline def getOption: S => Option[A] = optic.getter.getOption
-
-extension [S, T, A, B] (optic: POptic[GetOption & Modify, S, T, A, B])
-  inline def getOrModify: S => Either[T, A] = 
-    s => optic.getter.getOption(s).fold(Left(???))(Right.apply) 
-
-extension [ThisCan, S, A] (optic: Optic[ThisCan, S, A])
-  def index[I, A1](i: I)(using evIndex: Index[A, I, A1]): Optic[ThisCan | (GetOption & Modify), S, A1] = 
+  def index[I, A1](i: I)(using evIndex: Index[A, I, A1]): Optic[GetCan | GetOption, SetCan | Modify, S, A1] =
     optic.andThen(evIndex.index(i))
 
-extension [S, T, A, B] (optic: POptic[Modify, S, T, A, B])
+extension [S, T, A, B] (optic: POptic[GetMany, Any, S, T, A, B])
+  inline def foldMap[M: Monoid](f: A => M)(s: S): M = ???
+
+extension [S, T, A, B] (optic: POptic[GetOne, Any, S, T, A, B])
+  inline def get: S => A = optic.getter.get
+
+extension [S, T, A, B] (optic: POptic[GetMany, Any, S, T, A, B])
+  inline def getAll: S => List[A] = optic.getter.foldMap[List[A]](List(_))
+
+extension [S, T, A, B] (optic: POptic[GetOneOrMore, Any, S, T, A, B])
+  inline def getOneOrMore: S => NonEmptyList[A] = optic.getter.foldMap1[NonEmptyList[A]](NonEmptyList(_, Nil))
+
+extension [S, T, A, B] (optic: POptic[GetOption, Any, S, T, A, B])
+  inline def getOption: S => Option[A] = optic.getter.getOption
+
+extension [S, T, A, B] (optic: POptic[GetOption, Modify, S, T, A, B])
+  inline def getOrModify: S => Either[T, A] = 
+    s => optic.getter.getOption(s).fold(Left(???))(Right.apply)
+
+extension [S, T, A, B] (optic: POptic[Any, Modify, S, T, A, B])
   inline def modify(f: A => B): S => T = optic.setter.modify(f)
 
-extension [S, T, A, B] (optic: POptic[GetMany & Modify, S, T, A, B])
+extension [S, T, A, B] (optic: POptic[GetMany, Modify, S, T, A, B])
   inline def modifyA[F[_]: Applicative](f: A => F[B])(s: S): F[T] = ???
 
-extension [S, T, A, B] (optic: POptic[Modify, S, T, A, B])
+extension [S, T, A, B] (optic: POptic[Any, Modify, S, T, A, B])
   inline def replace(b: B): S => T = optic.setter.modify(_ => b)
   
-extension [S, T, A, B] (optic: POptic[ReverseGet, S, T, A, B])
+extension [S, T, A, B] (optic: POptic[Any, ReverseGet, S, T, A, B])
   inline def reverseGet: B => T = optic.setter.reverseGet
 
-extension [ThisCan, S, T, A, B] (optic: POptic[ThisCan, S, T, Option[A], Option[B]])
-  def some: POptic[ThisCan | GetOption, S, T, A, B] = optic.andThen(std.option.pSome)
+extension [GetCan, SetCan, S, T, A, B] (optic: POptic[GetCan, SetCan, S, T, Option[A], Option[B]])
+  def some: POptic[GetCan | GetOption, SetCan | ReverseGet, S, T, A, B] = optic.andThen(std.option.pSome)
 
-extension [ThisCan, S, A] (optic: Optic[ThisCan, S, Option[A]])
-  def withDefault(defaultValue: A): Optic[ThisCan | (GetOne & ReverseGet), S, A] = 
-    val iso: Optic[GetOne & ReverseGet, Option[A], A] = POptic(
+extension [GetCan, SetCan, S, A] (optic: Optic[GetCan, SetCan, S, Option[A]])
+  def withDefault(defaultValue: A): Optic[GetCan | GetOne, SetCan | ReverseGet, S, A] =
+    val iso: Optic[GetOne, ReverseGet, Option[A], A] = POptic(
       GetOneImpl(_.getOrElse(defaultValue)), 
       ReverseGetImpl(f => _.map(f), Some.apply))
     optic.andThen(iso)

--- a/src/main/scala/monocly/OpticBuilder.scala
+++ b/src/main/scala/monocly/OpticBuilder.scala
@@ -4,28 +4,23 @@ import monocly.internal._
 import monocly.impl._
 
 object OpticsBuilder:
-  type OnlyHasSetter[Can] = ReverseGet <:< Can
-  type OnlyHasGetter[Can] = GetOne <:< Can
 
-  extension [ThisCan <: Modify, S, T, A, B](optic: POptic[ThisCan, S, T, A, B])(using OnlyHasSetter[ThisCan])
-    def withGetOne(_getOne: S => A): POptic[ThisCan & GetOne, S, T, A, B] = 
-      POptic(GetOneImpl(_getOne), optic.setter.canAlso[ThisCan & GetOne])
+  extension [SetCan, S, T, A, B](optic: PSetter[SetCan, S, T, A, B])
+    def withGetOne(_getOne: S => A): POptic[GetOne, SetCan, S, T, A, B] =
+      POptic(GetOneImpl(_getOne), optic.setter)
 
-  extension [ThisCan <: Modify, S, T, A, B](optic: POptic[ThisCan, S, T, A, B])(using OnlyHasSetter[ThisCan])
-    def withGetOption(_getOption: S => Option[A]): POptic[ThisCan & GetOption, S, T, A, B] = 
-      POptic(GetOptionImpl(_getOption), optic.setter.canAlso[ThisCan & GetOption])
+    def withGetOption(_getOption: S => Option[A]): POptic[GetOption, SetCan, S, T, A, B] =
+      POptic(GetOptionImpl(_getOption), optic.setter)
 
-  extension [ThisCan <: Modify, S, T, A, B](optic: POptic[ThisCan, S, T, A, B])(using OnlyHasSetter[ThisCan])
-    def withGetOneOrMore(_getOneOrMore: S => NonEmptyList[A]): POptic[ThisCan & GetOneOrMore, S, T, A, B] = 
-      POptic(GetOneOrMoreImpl(_getOneOrMore), optic.setter.canAlso[ThisCan & GetOneOrMore])
+    def withGetOneOrMore(_getOneOrMore: S => NonEmptyList[A]): POptic[GetOneOrMore, SetCan, S, T, A, B] =
+      POptic(GetOneOrMoreImpl(_getOneOrMore), optic.setter)
 
-  extension [ThisCan <: Modify, S, T, A, B](optic: POptic[ThisCan, S, T, A, B])(using OnlyHasSetter[ThisCan])
-    def withGetMany(_getAll: S => List[A]): POptic[ThisCan & GetMany, S, T, A, B] = 
-      POptic(GetManyImpl(_getAll), optic.setter.canAlso[ThisCan & GetMany])
+    def withGetMany(_getAll: S => List[A]): POptic[GetMany, SetCan, S, T, A, B] =
+      POptic(GetManyImpl(_getAll), optic.setter)
 
-  extension [ThisCan <: GetMany, S, T, A, B](optic: POptic[ThisCan, S, T, A, B])(using OnlyHasGetter[ThisCan])
-    def withModify(_modify: (A => B) => S => T): POptic[ThisCan & Modify, S, T, A, B] = 
-      POptic(optic.getter.canAlso[ThisCan & Modify], ModifyImpl(_modify))
+  extension [GetCan, S, T, A, B](optic: POptic[GetCan, Any, S, T, A, B])
+    def withModify(_modify: (A => B) => S => T): POptic[GetCan, Modify, S, T, A, B] =
+      POptic(optic.getter, ModifyImpl(_modify))
 
   // extension [ThisCan <: GetOption, S, T, A, B](optic: POptic[ThisCan, S, T, A, B])(using OnlyHasGetter[ThisCan])
   //   def withReverseGet(_reverseGet: B => T): POptic[ThisCan & ReverseGet, S, T, A, B] = 
@@ -33,25 +28,25 @@ object OpticsBuilder:
   //            ReverseGetImpl(f => s => optic.getter.getOption(s).fold(optic.getter.returnUnmatched(s))
   //                                                                   (_reverseGet.compose(f)), _reverseGet))
 
-  def withGetOne[S, A](_get: S => A): Optic[GetOne, S, A] = 
+  def withGetOne[S, A](_get: S => A): Getter[GetOne, S, A] =
     POptic(GetOneImpl(_get), NoSetter)
 
-  def withGetOption[S, A](_getOption: S => Option[A]): Optic[GetOption, S, A] = 
+  def withGetOption[S, A](_getOption: S => Option[A]): Getter[GetOption, S, A] =
     POptic(GetOptionImpl(_getOption), NoSetter)
 
-  def withGetOneOrMore[S, A](_getOneOrMore: S => NonEmptyList[A]): Optic[GetOneOrMore, S, A] = 
+  def withGetOneOrMore[S, A](_getOneOrMore: S => NonEmptyList[A]): Getter[GetOneOrMore, S, A] =
     POptic(GetOneOrMoreImpl(_getOneOrMore), NoSetter)
 
-  def withGetMany[S,A](_getList: S => List[A]): Optic[GetMany, S, A] = 
+  def withGetMany[S,A](_getList: S => List[A]): Getter[GetMany, S, A] =
     POptic(GetManyImpl(_getList), NoSetter)
 
-  def withModify[S, T, A, B](_modify: (A => B) => S => T): POptic[Modify, S, T, A, B] = 
+  def withModify[S, T, A, B](_modify: (A => B) => S => T): PSetter[Modify, S, T, A, B] =
     POptic(NoGetter, ModifyImpl(_modify))
 
-  def withReverseGet[S, T, A, B](_modify: (A => B) => S => T, _reverseGet: B => T): POptic[ReverseGet, S, T, A, B] = 
+  def withReverseGet[S, T, A, B](_modify: (A => B) => S => T, _reverseGet: B => T): PSetter[ReverseGet, S, T, A, B] =
     POptic(NoGetter, ReverseGetImpl(_modify, _reverseGet))
 
-  def withLens[S, A](_get: S => A)(_set: A => S => S): Optic[GetOne & Modify, S, A] = 
-    withGetOne(_get).withModify(f => s => _set(f(_get(s)))(s))
+  def withLens[S, A](_get: S => A)(_set: A => S => S): Optic[GetOne, Modify, S, A] =
+    Lens(_get, _set)
 
 end OpticsBuilder

--- a/src/main/scala/monocly/OpticBuilder.scala
+++ b/src/main/scala/monocly/OpticBuilder.scala
@@ -4,8 +4,8 @@ import monocly.internal._
 import monocly.impl._
 
 object OpticsBuilder:
-  type OnlyHasSetter[Can <: OpticCan] = ReverseGet <:< Can
-  type OnlyHasGetter[Can <: OpticCan] = GetOne <:< Can
+  type OnlyHasSetter[Can] = ReverseGet <:< Can
+  type OnlyHasGetter[Can] = GetOne <:< Can
 
   extension [ThisCan <: Modify, S, T, A, B](optic: POptic[ThisCan, S, T, A, B])(using OnlyHasSetter[ThisCan])
     def withGetOne(_getOne: S => A): POptic[ThisCan & GetOne, S, T, A, B] = 

--- a/src/main/scala/monocly/OpticCan.scala
+++ b/src/main/scala/monocly/OpticCan.scala
@@ -1,7 +1,5 @@
 package monocly
 
-sealed trait OpticCan
-
 //        GetMany
 //          /\
 //         /  \
@@ -9,7 +7,8 @@ sealed trait OpticCan
 //         \  /
 //          \/
 //        GetOne
-trait GetMany extends OpticCan
+sealed trait GetteCan
+trait GetMany extends GetteCan
 trait GetOption extends GetMany
 trait GetOneOrMore extends GetMany
 trait GetOne extends GetOption with GetOneOrMore
@@ -18,5 +17,6 @@ trait GetOne extends GetOption with GetOneOrMore
 //      ^
 //      |
 //  ReverseGet
-trait Modify extends OpticCan
+sealed trait SetterCan
+trait Modify extends SetterCan
 trait ReverseGet extends Modify

--- a/src/main/scala/monocly/OpticCan.scala
+++ b/src/main/scala/monocly/OpticCan.scala
@@ -1,0 +1,22 @@
+package monocly
+
+sealed trait OpticCan
+
+//        GetMany
+//          /\
+//         /  \
+// GetOption  GetOneOrMore
+//         \  /
+//          \/
+//        GetOne
+trait GetMany extends OpticCan
+trait GetOption extends GetMany
+trait GetOneOrMore extends GetMany
+trait GetOne extends GetOption with GetOneOrMore
+
+//    Modify
+//      ^
+//      |
+//  ReverseGet
+trait Modify extends OpticCan
+trait ReverseGet extends Modify

--- a/src/main/scala/monocly/PIso.scala
+++ b/src/main/scala/monocly/PIso.scala
@@ -5,7 +5,7 @@ import monocly.impl._
 import monocly.internal.Applicative
 import monocly.functions.Index
 
-type PIso[-S, +T, +A, -B] = POptic[GetOne & ReverseGet, S, T, A, B]
+type PIso[-S, +T, +A, -B] = POptic[GetOne, ReverseGet, S, T, A, B]
 type Iso[S, A] = PIso[S, S, A, A]
 
 object PIso:

--- a/src/main/scala/monocly/PLens.scala
+++ b/src/main/scala/monocly/PLens.scala
@@ -4,7 +4,7 @@ import monocly.internal.Applicative
 import monocly.functions.Index
 import monocly.impl._
 
-type PLens[-S, +T, +A, -B] = POptic[GetOne & Modify, S, T, A, B]
+type PLens[-S, +T, +A, -B] = POptic[GetOne, Modify, S, T, A, B]
 type Lens[S, A] = PLens[S, S, A, A]
 
 object PLens:

--- a/src/main/scala/monocly/POptional.scala
+++ b/src/main/scala/monocly/POptional.scala
@@ -4,7 +4,7 @@ import monocly.internal.{Applicative, Id}
 import monocly.functions.Index
 import monocly.impl._
 
-type POptional[-S, +T, +A, -B] = POptic[GetOption & Modify, S, T, A, B]
+type POptional[-S, +T, +A, -B] = POptic[GetOption, Modify, S, T, A, B]
 type Optional[S, A] = POptional[S, S, A, A]
 
 

--- a/src/main/scala/monocly/PPrism.scala
+++ b/src/main/scala/monocly/PPrism.scala
@@ -4,7 +4,7 @@ import monocly.internal.Applicative
 import monocly.functions.Index
 import monocly.impl._
 
-type PPrism[-S, +T, +A, -B] = POptic[GetOption & ReverseGet, S, T, A, B]
+type PPrism[-S, +T, +A, -B] = POptic[GetOption, ReverseGet, S, T, A, B]
 type Prism[S, A] = PPrism[S, S, A, A] 
 
 

--- a/src/main/scala/monocly/PTraversal.scala
+++ b/src/main/scala/monocly/PTraversal.scala
@@ -4,7 +4,7 @@ import monocly.internal.{Applicative, Id, Proxy}
 import monocly.functions.Index
 import monocly.impl._
 
-type PTraversal[-S, +T, +A, -B] = POptic[GetMany & Modify, S, T, A, B]
+type PTraversal[-S, +T, +A, -B] = POptic[GetMany, Modify, S, T, A, B]
 type Traversal[From, To] = PTraversal[From, From, To, To]
 
 object PTraversal:

--- a/src/main/scala/monocly/functions/Each.scala
+++ b/src/main/scala/monocly/functions/Each.scala
@@ -3,4 +3,4 @@ package monocly.functions
 import monocly._
 
 abstract class Each[S, A]:
-  def each: Optic[GetMany & Modify, S, A]
+  def each: Optic[GetMany, Modify, S, A]

--- a/src/main/scala/monocly/impl/GetManyImpl.scala
+++ b/src/main/scala/monocly/impl/GetManyImpl.scala
@@ -33,7 +33,7 @@ trait GetManyImpl[+ThisCan <: GetMany, -S, +A] extends GetterImpl[ThisCan, S, A]
       override def _foldMap[M: Monoid](f: A => M): S0 => M = 
         s0 => self.foldMap(f)(impl1.get(s0))
 
-  override def andThen[ThatCan <: OpticCan, C](impl2: GetterImpl[ThatCan, A, C]): GetterImpl[ThisCan | ThatCan, S, C] = 
+  override def andThen[ThatCan, C](impl2: GetterImpl[ThatCan, A, C]): GetterImpl[ThisCan | ThatCan, S, C] =
     impl2.preComposeGetMany(this)
 
   override def foldMap[M](f: A => M)(using Monoid[M], ThisCan <:< GetMany): S => M = _foldMap(f)

--- a/src/main/scala/monocly/impl/GetOneImpl.scala
+++ b/src/main/scala/monocly/impl/GetOneImpl.scala
@@ -21,7 +21,7 @@ class GetOneImpl[+ThisCan <: GetOne, -S, +A](_get: S => A) extends GetterImpl[Th
   override def preComposeGetOne[ThatCan <: GetOne, S0](impl1: GetOneImpl[ThatCan, S0, S]): GetOneImpl[ThisCan | ThatCan, S0, A] = 
     GetOneImpl(s0 => get(impl1.get(s0)))
 
-  def andThen[ThatCan <: OpticCan, C](impl2: GetterImpl[ThatCan, A, C]): GetterImpl[ThisCan | ThatCan, S, C] = 
+  def andThen[ThatCan, C](impl2: GetterImpl[ThatCan, A, C]): GetterImpl[ThisCan | ThatCan, S, C] =
     impl2.preComposeGetOne(this)
 
   override def get(using ThisCan <:< GetOne): S => A = _get

--- a/src/main/scala/monocly/impl/GetOneOrMore.scala
+++ b/src/main/scala/monocly/impl/GetOneOrMore.scala
@@ -35,7 +35,7 @@ trait GetOneOrMoreImpl[+ThisCan <: GetOneOrMore, -S, +A] extends GetterImpl[This
       override def _foldMap1[M: Semigroup](f: A => M): S0 => M = 
         s0 => self.foldMap1(f)(impl1.get(s0))
 
-  override def andThen[ThatCan <: OpticCan, C](impl2: GetterImpl[ThatCan, A, C]): GetterImpl[ThisCan | ThatCan, S, C] = 
+  override def andThen[ThatCan, C](impl2: GetterImpl[ThatCan, A, C]): GetterImpl[ThisCan | ThatCan, S, C] =
     impl2.preComposeGetOneOrMore(this)
 
   override def foldMap1[M](f: A => M)(using Semigroup[M], ThisCan <:< GetOneOrMore): S => M = _foldMap1(f)

--- a/src/main/scala/monocly/impl/GetOptionImpl.scala
+++ b/src/main/scala/monocly/impl/GetOptionImpl.scala
@@ -22,7 +22,7 @@ class GetOptionImpl[+ThisCan <: GetOption, -S, +A](_getOption: S => Option[A]) e
   override def preComposeGetOne[ThatCan <: GetOne, S0](impl1: GetOneImpl[ThatCan, S0, S]): GetOptionImpl[ThisCan | ThatCan, S0, A] = 
     GetOptionImpl(s0 => impl1.getOption(s0).flatMap(getOption))
 
-  def andThen[ThatCan <: OpticCan, C](impl2: GetterImpl[ThatCan, A, C]): GetterImpl[ThisCan | ThatCan, S, C] = 
+  def andThen[ThatCan, C](impl2: GetterImpl[ThatCan, A, C]): GetterImpl[ThisCan | ThatCan, S, C] =
     impl2.preComposeGetOption(this)
 
   override def getOption(using ThisCan <:< GetOption): S => Option[A] = _getOption

--- a/src/main/scala/monocly/impl/GetterImpl.scala
+++ b/src/main/scala/monocly/impl/GetterImpl.scala
@@ -4,9 +4,9 @@ import monocly.internal._
 import monocly._
 
 
-trait GetterImpl[+ThisCan <: OpticCan, -S, +A]:
+trait GetterImpl[+ThisCan, -S, +A]:
 
-  def canAlso[NewCan <: OpticCan]: GetterImpl[NewCan, S, A] = 
+  def canAlso[NewCan <: OpticCan]: GetterImpl[NewCan, S, A] =
     asInstanceOf[GetterImpl[NewCan, S, A]]
 
   def preComposeGetMany[ThatCan <: GetMany, S0](impl1: GetManyImpl[ThatCan, S0, S]): GetterImpl[ThisCan | ThatCan, S0, A]
@@ -14,7 +14,7 @@ trait GetterImpl[+ThisCan <: OpticCan, -S, +A]:
   def preComposeGetOption[ThatCan <: GetOption, S0](impl1: GetOptionImpl[ThatCan, S0, S]): GetterImpl[ThisCan | ThatCan, S0, A]
   def preComposeGetOne[ThatCan <: GetOne, S0](impl1: GetOneImpl[ThatCan, S0, S]): GetterImpl[ThisCan | ThatCan, S0, A]
 
-  def andThen[ThatCan <: OpticCan, C](impl2: GetterImpl[ThatCan, A, C]): GetterImpl[ThisCan | ThatCan, S, C]
+  def andThen[ThatCan, C](impl2: GetterImpl[ThatCan, A, C]): GetterImpl[ThisCan | ThatCan, S, C]
 
   def get(using ThisCan <:< GetOne): S => A = sys.error("This optic does not support 'get'")
   def getOption(using ThisCan <:< GetOption): S => Option[A] = sys.error("This optic does not support 'getOption'")

--- a/src/main/scala/monocly/impl/GetterImpl.scala
+++ b/src/main/scala/monocly/impl/GetterImpl.scala
@@ -6,7 +6,7 @@ import monocly._
 
 trait GetterImpl[+ThisCan, -S, +A]:
 
-  def canAlso[NewCan <: OpticCan]: GetterImpl[NewCan, S, A] =
+  def canAlso[NewCan <: GetteCan]: GetterImpl[NewCan, S, A] =
     asInstanceOf[GetterImpl[NewCan, S, A]]
 
   def preComposeGetMany[ThatCan <: GetMany, S0](impl1: GetManyImpl[ThatCan, S0, S]): GetterImpl[ThisCan | ThatCan, S0, A]

--- a/src/main/scala/monocly/impl/ModifyImpl.scala
+++ b/src/main/scala/monocly/impl/ModifyImpl.scala
@@ -10,7 +10,7 @@ class ModifyImpl[ThisCan <: Modify, -S, +T, +A, -B](_modify: (A => B) => S => T)
   override def preComposeReverseGet[ThatCan <: ReverseGet, S0, T0](impl1: ReverseGetImpl[ThatCan, S0, T0, S, T]): ModifyImpl[ThisCan | ThatCan, S0, T0, A, B] = 
     ModifyImpl(f => s0 => impl1.modify(s => modify(f)(s))(s0))
 
-  override def andThen[ThatCan <: OpticCan, C, D](impl2: SetterImpl[ThatCan, A, B, C, D]): SetterImpl[ThisCan | ThatCan, S, T, C, D] = 
+  override def andThen[ThatCan, C, D](impl2: SetterImpl[ThatCan, A, B, C, D]): SetterImpl[ThisCan | ThatCan, S, T, C, D] =
     impl2.preComposeModify(this)
 
   override def modify(f: A => B)(using ThisCan <:< Modify): S => T = _modify(f)

--- a/src/main/scala/monocly/impl/NoGetter.scala
+++ b/src/main/scala/monocly/impl/NoGetter.scala
@@ -7,5 +7,5 @@ object NoGetter extends GetterImpl[Nothing, Any, Nothing]:
   override def preComposeGetOneOrMore[ThatCan <: GetOneOrMore, S0](impl1: GetOneOrMoreImpl[ThatCan, S0, Any]) = NoGetter
   override def preComposeGetOption[ThatCan <: GetOption, S0](impl1: GetOptionImpl[ThatCan, S0, Any]) = NoGetter
   override def preComposeGetOne[ThatCan <: GetOne, S0](impl1: GetOneImpl[ThatCan, S0, Any]) = NoGetter
-  override def andThen[ThatCan <: OpticCan, C](impl2: GetterImpl[ThatCan, Nothing, C]) = NoGetter
+  override def andThen[ThatCan, C](impl2: GetterImpl[ThatCan, Nothing, C]) = NoGetter
 end NoGetter

--- a/src/main/scala/monocly/impl/NoGetter.scala
+++ b/src/main/scala/monocly/impl/NoGetter.scala
@@ -2,7 +2,7 @@ package monocly.impl
 
 import monocly._
 
-object NoGetter extends GetterImpl[Nothing, Any, Nothing]:
+object NoGetter extends GetterImpl[Any, Any, Nothing]:
   override def preComposeGetMany[ThatCan <: GetMany, S0](impl1: GetManyImpl[ThatCan, S0, Any]) = NoGetter
   override def preComposeGetOneOrMore[ThatCan <: GetOneOrMore, S0](impl1: GetOneOrMoreImpl[ThatCan, S0, Any]) = NoGetter
   override def preComposeGetOption[ThatCan <: GetOption, S0](impl1: GetOptionImpl[ThatCan, S0, Any]) = NoGetter

--- a/src/main/scala/monocly/impl/NoSetter.scala
+++ b/src/main/scala/monocly/impl/NoSetter.scala
@@ -5,5 +5,5 @@ import monocly._
 object NoSetter extends SetterImpl[Nothing, Any, Nothing, Nothing, Any]:
   override def preComposeModify[ThatCan <: Modify, S0, T0](impl1: ModifyImpl[ThatCan, S0, T0, Any, Nothing]) = NoSetter
   override def preComposeReverseGet[ThatCan <: ReverseGet, S0, T0](impl1: ReverseGetImpl[ThatCan, S0, T0, Any, Nothing]) = NoSetter
-  override def andThen[ThatCan <: OpticCan, C, D](impl2: SetterImpl[ThatCan, Nothing, Any, C, D]) = NoSetter
+  override def andThen[ThatCan, C, D](impl2: SetterImpl[ThatCan, Nothing, Any, C, D]) = NoSetter
 end NoSetter

--- a/src/main/scala/monocly/impl/NoSetter.scala
+++ b/src/main/scala/monocly/impl/NoSetter.scala
@@ -2,7 +2,7 @@ package monocly.impl
 
 import monocly._
 
-object NoSetter extends SetterImpl[Nothing, Any, Nothing, Nothing, Any]:
+object NoSetter extends SetterImpl[Any, Any, Nothing, Nothing, Any]:
   override def preComposeModify[ThatCan <: Modify, S0, T0](impl1: ModifyImpl[ThatCan, S0, T0, Any, Nothing]) = NoSetter
   override def preComposeReverseGet[ThatCan <: ReverseGet, S0, T0](impl1: ReverseGetImpl[ThatCan, S0, T0, Any, Nothing]) = NoSetter
   override def andThen[ThatCan, C, D](impl2: SetterImpl[ThatCan, Nothing, Any, C, D]) = NoSetter

--- a/src/main/scala/monocly/impl/ReverseGetImpl.scala
+++ b/src/main/scala/monocly/impl/ReverseGetImpl.scala
@@ -12,7 +12,7 @@ class ReverseGetImpl[ThisCan <: ReverseGet, -S, +T, +A, -B](_modify: (A => B) =>
       f => s0 => impl1.modify(s => modify(f)(s))(s0), 
       b => impl1.reverseGet(reverseGet(b)))
 
-  override def andThen[ThatCan <: OpticCan, C, D](impl2: SetterImpl[ThatCan, A, B, C, D]): SetterImpl[ThisCan | ThatCan, S, T, C, D] = 
+  override def andThen[ThatCan, C, D](impl2: SetterImpl[ThatCan, A, B, C, D]): SetterImpl[ThisCan | ThatCan, S, T, C, D] =
     impl2.preComposeReverseGet(this)
 
   override def modify(f: A => B)(using ThisCan <:< Modify): S => T = _modify(f)

--- a/src/main/scala/monocly/impl/SetterImpl.scala
+++ b/src/main/scala/monocly/impl/SetterImpl.scala
@@ -2,15 +2,15 @@ package monocly.impl
 
 import monocly._
 
-trait SetterImpl[+ThisCan <: OpticCan, -S, +T, +A, -B]:
+trait SetterImpl[+ThisCan, -S, +T, +A, -B]:
 
-  def canAlso[NewCan <: OpticCan]: SetterImpl[NewCan, S, T, A, B] = 
+  def canAlso[NewCan <: OpticCan]: SetterImpl[NewCan, S, T, A, B] =
     asInstanceOf[SetterImpl[NewCan, S, T, A, B]]
 
   def preComposeModify[ThatCan <: Modify, S0, T0](impl1: ModifyImpl[ThatCan, S0, T0, S, T]): SetterImpl[ThisCan | ThatCan, S0, T0, A, B]
   def preComposeReverseGet[ThatCan <: ReverseGet, S0, T0](impl1: ReverseGetImpl[ThatCan, S0, T0, S, T]): SetterImpl[ThisCan | ThatCan, S0, T0, A, B]
 
-  def andThen[ThatCan <: OpticCan, C, D](impl2: SetterImpl[ThatCan, A, B, C, D]): SetterImpl[ThisCan | ThatCan, S, T, C, D]
+  def andThen[ThatCan, C, D](impl2: SetterImpl[ThatCan, A, B, C, D]): SetterImpl[ThisCan | ThatCan, S, T, C, D]
 
   def modify(f: A => B)(using ThisCan <:< Modify): S => T = sys.error("This optic does not support 'modify'")
   def reverseGet(using ThisCan <:< ReverseGet): B => T = sys.error("This optic does not support 'replaceAll'")

--- a/src/main/scala/monocly/impl/SetterImpl.scala
+++ b/src/main/scala/monocly/impl/SetterImpl.scala
@@ -4,7 +4,7 @@ import monocly._
 
 trait SetterImpl[+ThisCan, -S, +T, +A, -B]:
 
-  def canAlso[NewCan <: OpticCan]: SetterImpl[NewCan, S, T, A, B] =
+  def canAlso[NewCan <: SetterCan]: SetterImpl[NewCan, S, T, A, B] =
     asInstanceOf[SetterImpl[NewCan, S, T, A, B]]
 
   def preComposeModify[ThatCan <: Modify, S0, T0](impl1: ModifyImpl[ThatCan, S0, T0, S, T]): SetterImpl[ThisCan | ThatCan, S0, T0, A, B]

--- a/src/main/scala/monocly/std/option.scala
+++ b/src/main/scala/monocly/std/option.scala
@@ -4,8 +4,8 @@ import monocly._
 import monocly.impl._
 
 object option:
-  def pSome[A, B]: POptic[GetOption & ReverseGet, Option[A], Option[B], A, B] =
+  def pSome[A, B]: POptic[GetOption, ReverseGet, Option[A], Option[B], A, B] =
     POptic(GetOptionImpl(identity), ReverseGetImpl(f => _.map(f), Some.apply))
 
-  def some[A]: Optic[GetOption & ReverseGet, Option[A], A] =
+  def some[A]: Optic[GetOption, ReverseGet, Option[A], A] =
     pSome[A, A]

--- a/src/test/scala/optics/poly/NewOpticsTest.scala
+++ b/src/test/scala/optics/poly/NewOpticsTest.scala
@@ -13,13 +13,13 @@ class NewOpticsTest extends munit.FunSuite {
 
 
   test("GetOne andThen GetOne") {
-    val deskOptic: Optic[GetOne, Office, Desk] = 
+    val deskOptic: Getter[GetOne, Office, Desk] =
       OpticsBuilder.withGetOne(_.desk)
 
-    val pensOptic: Optic[GetOne, Desk, Int] = 
+    val pensOptic: Getter[GetOne, Desk, Int] =
       OpticsBuilder.withGetOne(_.numPens)
 
-    val composed: Optic[GetOne, Office, Int] = 
+    val composed: Getter[GetOne, Office, Int] =
       deskOptic.andThen(pensOptic)
 
     val office = Office(Desk(5, None), Nil)
@@ -27,13 +27,13 @@ class NewOpticsTest extends munit.FunSuite {
   }
 
   test("GetOption andThen GetOne") {
-    val printerOptic: Optic[GetOption, Desk, Printer] = 
+    val printerOptic: Getter[GetOption, Desk, Printer] =
       OpticsBuilder.withGetOption(_.printer)
 
-    val pcLoadLetterOptic: Optic[GetOne, Printer, Boolean] = 
+    val pcLoadLetterOptic: Getter[GetOne, Printer, Boolean] =
       OpticsBuilder.withGetOne(_.pcLoadLetter)
 
-    val composed: Optic[GetOption, Desk, Boolean] = 
+    val composed: Getter[GetOption, Desk, Boolean] =
       printerOptic.andThen(pcLoadLetterOptic)
 
     val desk = Desk(5, Some(Printer(true)))
@@ -41,13 +41,13 @@ class NewOpticsTest extends munit.FunSuite {
   }
 
   test("GetMany andThen GetOne") {
-    val pensOptic: Optic[GetMany, Office, Pen] = 
+    val pensOptic: Getter[GetMany, Office, Pen] =
       OpticsBuilder.withGetMany(_.pens)
 
-    val colorOptic: Optic[GetOne, Pen, String] = 
+    val colorOptic: Getter[GetOne, Pen, String] =
       OpticsBuilder.withGetOne(_.color)
 
-    val composed: Optic[GetMany, Office, String] = 
+    val composed: Getter[GetMany, Office, String] =
       pensOptic.andThen(colorOptic)
 
     val office = Office(Desk(5, None), List(Pen("red"), Pen("green"), Pen("blue")))
@@ -56,12 +56,12 @@ class NewOpticsTest extends munit.FunSuite {
 
   test("Modify andThen Modify") {
 
-    val modifyPrinter: Optic[Modify, Desk, Printer] = 
+    val modifyPrinter: Setter[Modify, Desk, Printer] =
       OpticsBuilder.withModify(f => desk => desk.copy(printer = desk.printer.map(f)))
-    val modifyPcLoadLetter: Optic[Modify, Printer, Boolean] = 
+    val modifyPcLoadLetter: Setter[Modify, Printer, Boolean] =
       OpticsBuilder.withModify(f => printer => printer.copy(pcLoadLetter = f(printer.pcLoadLetter)))
 
-    val composed: Optic[Modify, Desk, Boolean] = 
+    val composed: Setter[Modify, Desk, Boolean] =
       modifyPrinter.andThen(modifyPcLoadLetter)
 
     val desk = Desk(5, Some(Printer(true)))
@@ -72,13 +72,13 @@ class NewOpticsTest extends munit.FunSuite {
 
   test("ReverseGet andThen Modify") {
 
-    val modifyPens: Optic[Modify, Office, Pen] = 
+    val modifyPens: Setter[Modify, Office, Pen] =
       OpticsBuilder.withModify(f => office => office.copy(pens = office.pens.map(f)))
 
-    val reverseGetColor: Optic[ReverseGet, Pen, String] = 
+    val reverseGetColor: Setter[ReverseGet, Pen, String] =
       OpticsBuilder.withReverseGet[Pen, Pen, String, String](f => pen => pen.copy(color = f(pen.color)), Pen(_))
 
-    val composed: Optic[Modify, Office, String] = 
+    val composed: Setter[Modify, Office, String] =
       modifyPens.andThen(reverseGetColor)
 
     val office = Office(Desk(5, None), List(Pen("blue"), Pen("yellow")))
@@ -88,13 +88,13 @@ class NewOpticsTest extends munit.FunSuite {
   }
 
   test("Lens andThen GetOne") {
-    val deskOptic: Optic[GetOne & Modify, Office, Desk] = 
+    val deskOptic: Optic[GetOne, Modify, Office, Desk] =
       OpticsBuilder.withLens[Office, Desk](_.desk)(d => _.copy(desk = d))
 
-    val pensOptic: Optic[GetOne, Desk, Int] = 
+    val pensOptic: Getter[GetOne, Desk, Int] =
       OpticsBuilder.withGetOne(_.numPens)
 
-    val composed: Optic[GetOne, Office, Int] = 
+    val composed: Getter[GetOne, Office, Int] =
       deskOptic.andThen(pensOptic)
 
     val office = Office(Desk(5, None), Nil)
@@ -102,13 +102,13 @@ class NewOpticsTest extends munit.FunSuite {
   }
 
   test("Lens andThen Lens") {
-    val deskOptic: Optic[GetOne & Modify, Office, Desk] = 
+    val deskOptic: Optic[GetOne, Modify, Office, Desk] =
       OpticsBuilder.withLens[Office, Desk](_.desk)(d => _.copy(desk = d))
 
-    val pensOptic: Optic[GetOne & Modify, Desk, Int] = 
+    val pensOptic: Optic[GetOne, Modify, Desk, Int] =
       OpticsBuilder.withLens[Desk, Int](_.numPens)(n => _.copy(numPens = n))
 
-    val composed: Optic[GetOne & Modify, Office, Int] = 
+    val composed: Optic[GetOne, Modify, Office, Int] =
       deskOptic.andThen(pensOptic)
 
     val office = Office(Desk(55, None), Nil)
@@ -119,13 +119,13 @@ class NewOpticsTest extends munit.FunSuite {
   }
 
   test("GetOneOrMore andThen GetOne") {
-    val pensOptic: Optic[GetOneOrMore, Office, Pen] = 
+    val pensOptic: Getter[GetOneOrMore, Office, Pen] =
       OpticsBuilder.withGetOneOrMore(o => NonEmptyList(Pen("rainbow"), o.pens))
 
-    val colorOptic: Optic[GetOne, Pen, String] = 
+    val colorOptic: Getter[GetOne, Pen, String] =
       OpticsBuilder.withGetOne(_.color)
 
-    val composed: Optic[GetOneOrMore, Office, String] = 
+    val composed: Getter[GetOneOrMore, Office, String] =
       pensOptic.andThen(colorOptic)
 
     val office = Office(Desk(5, None), List(Pen("red"), Pen("green"), Pen("blue")))
@@ -133,13 +133,13 @@ class NewOpticsTest extends munit.FunSuite {
   }
 
   test("GetOneOrMore andThen GetOption") {
-    val pensOptic: Optic[GetOneOrMore, Office, Pen] = 
+    val pensOptic: Getter[GetOneOrMore, Office, Pen] =
       OpticsBuilder.withGetOneOrMore(o => NonEmptyList(Pen("rainbow", Some(Company("Hemingsworth"))), o.pens))
 
-    val manufacturerOptic: Optic[GetOption, Pen, Company] = 
+    val manufacturerOptic: Getter[GetOption, Pen, Company] =
       OpticsBuilder.withGetOption(_.manufacturer)
 
-    val composed: Optic[GetMany, Office, Company] = 
+    val composed: Getter[GetMany, Office, Company] =
       pensOptic.andThen(manufacturerOptic)
 
     val office = Office(Desk(5, None), List(Pen("red", Some(Company("Pencorp"))), Pen("green"), Pen("blue")))


### PR DESCRIPTION
## AndThen

`andThen` of `POptic` is verbose but it is very similar to `flatMap` of `Either`. I used `ThatGetCan >: GetCan` to infer the LUB.

```scala
final class POptic[+GetCan, +SetCan, -S, +T, +A, -B] private[monocly](
    protected[monocly] val getter: GetterImpl[GetCan, S, A],
    protected[monocly] val setter: SetterImpl[SetCan, S, T, A, B]):

  def andThen[ThatGetCan >: GetCan, ThatSetCan >: SetCan, C, D](
   o: POptic[ThatGetCan, ThatSetCan, A, B, C, D]
  ): POptic[ThatGetCan, ThatSetCan, S, T, C, D] =
    POptic(getter.andThen(o.getter), setter.andThen(o.setter))

end POptic
```

## Optic Alias and Any

Interestingly, it seems that we should use `Any` in `NoGetter` and `NoSetter`. `Nothing` actually means anything you want since the type parameter is covariant.

```
type Getter[+GetCan, S, A] = Optic[GetCan, Any, S, A]
type Setter[+SetCan, S, A] = Optic[Any, SetCan, S, A]

object NoGetter extends GetterImpl[Any, Any, Nothing]
object NoSetter extends SetterImpl[Any, Any, Nothing, Nothing, Any]
```

