### PR TITLE
Permission issue

### DIFF
--- a/src/test/scala/monocly/impl/GetterImplTest.scala
+++ b/src/test/scala/monocly/impl/GetterImplTest.scala
@@ -1,0 +1,23 @@
+package monocly.impl
+
+import munit.FunSuite
+
+class GetterImplTest extends munit.FunSuite {
+
+  test("GetMany getOne") {
+    val getter = GetManyImpl((x: List[Int]) => x)
+    val input = List(1,2,3)
+    assertEquals(
+      getter.get(input),
+      1
+    )
+  }
+
+  test("GetMany getOne doesn't compile") {
+    assertNoDiff(
+      compileErrors("GetManyImpl((x: List[Int]) => x).get(List(1,2,3))"),
+      "Error: ..."
+    )
+  }
+
+}

--- a/src/test/scala/monocly/impl/GetterImplTest.scala
+++ b/src/test/scala/monocly/impl/GetterImplTest.scala
@@ -20,4 +20,11 @@ class GetterImplTest extends munit.FunSuite {
     )
   }
 
+  test("NoGetter getOne doesn't compile") {
+    assertNoDiff(
+      compileErrors("NoGetter.get(1)"),
+      "Error: ..."
+    )
+  }
+
 }


### PR DESCRIPTION
This PR is to illustarte an issue with permissions of `Getter`/`Setter` Impl.

Currently, `val getter = GetManyImpl((x: List[Int]) => x)` infers `ThisCan = Nothing`  while it should infer `GetMany`.

Similarly, `NoGetter` should use `ThisCan = Any`