### PR TITLE
Introducing OpticGet to fix up getters

### DIFF
--- a/src/main/scala/monocle/Optic.scala
+++ b/src/main/scala/monocle/Optic.scala
@@ -6,7 +6,7 @@ import monocle.internal.*
  
 
 type Optic[+ThisCan, S, A] = POptic[ThisCan, S, S, A, A]
-type OpticGet[ThisCan >: Get, -S, +A] = POptic[ThisCan, S, Nothing, A, Any]
+type OpticGet[+ThisCan, -S, +A] = POptic[ThisCan, S, Nothing, A, Any]
 
 object GetOptic:
   def id[A]: OpticGet[Get, A, A] = 
@@ -182,8 +182,8 @@ extension [ThisCan, S, T, A, B] (self: POptic[ThisCan, S, T, Option[A], Option[B
   def some: POptic[ThisCan | GetOption, S, T, A, B] = 
     self.andThen(std.option.pSome)
 
-extension [S, T, A, B] (self: POptic[GetMany, S, T, A, B])
-  def to[C](f: A => C): POptic[GetMany, S, Any, C, Nothing] = 
+extension [ThisCan <: GetMany, NewCan >: ThisCan | Get, S, T, A, B] (self: POptic[ThisCan, S, T, A, B])
+  def to[C](f: A => C): POptic[NewCan, S, Any, C, Nothing] = 
     self.andThen(Optic.thatCan.get(f))
 
 extension [ThisCan, S, T, A, B] (self: POptic[ThisCan, S, T, Option[A], Option[B]])

--- a/src/main/scala/monocle/OpticConstructors.scala
+++ b/src/main/scala/monocle/OpticConstructors.scala
@@ -6,30 +6,30 @@ import monocle.internal.*
 
 trait OpticConstructors(polyConstructors: POpticConstructors):
 
-  def get[S, A](_get: S => A): Optic[Get, S, A] = 
+  def get[S, A](_get: S => A): OpticGet[Get, S, A] = 
     POptic(
       new GetterImpl:
         override def get(s: S): A = _get(s))
         
-  def get2[S, A](_get1: S => A, _get2: S => A): Optic[GetOneOrMore, S, A] = 
+  def get2[S, A](_get1: S => A, _get2: S => A): OpticGet[GetOneOrMore, S, A] = 
     POptic(
       new NonEmptyFoldImpl:
         override def nonEmptyFoldMap[M: Semigroup](f: A => M)(s: S): M = 
           Semigroup[M].combine(f(_get1(s)), f(_get2(s))))
 
-  def getOption[S, A](_getOption: S => Option[A]): Optic[GetOption, S, A] = 
+  def getOption[S, A](_getOption: S => Option[A]): OpticGet[GetOption, S, A] = 
     POptic(
       new OptionalGetterImpl:
         override def getOption(s: S): Option[A] = _getOption(s))
 
-  def getOneOrMore[S, A](_getOneOrMore: S => NonEmptyList[A]): Optic[GetOneOrMore, S, A] = 
+  def getOneOrMore[S, A](_getOneOrMore: S => NonEmptyList[A]): OpticGet[GetOneOrMore, S, A] = 
     POptic(
       new NonEmptyFoldImpl:
         override def nonEmptyFoldMap[M](f: A => M)(s: S)(using sem: Semigroup[M]): M = 
           val NonEmptyList(head, tail) = _getOneOrMore(s)
           tail.foldLeft(f(head))((m, a) => sem.combine(m, f(a))))
 
-  def getMany[S, A](_getAll: S => List[A]): Optic[GetMany, S, A] = 
+  def getMany[S, A](_getAll: S => List[A]): OpticGet[GetMany, S, A] = 
     POptic(
       new FoldImpl:
         override def foldMap[M](f: A => M)(s: S)(using mon: Monoid[M]): M = 

--- a/src/test/scala/Fixtures.scala
+++ b/src/test/scala/Fixtures.scala
@@ -1,6 +1,20 @@
 package monocle
 
 object Fixtures:
+
+  trait Animal
+  case class Tiger(stripes: Int) extends Animal
+  case class Zoo(tiger: Tiger)
+  case class Photo(animal: Animal)
+
+  val tigerStripes = Optic.thatCan.edit[Tiger, Int](_.stripes)(s => _.copy(stripes = s))
+  val zooTiger = Optic.thatCan.edit[Zoo, Tiger](_.tiger)(t => _.copy(tiger = t))
+  val getZooTiger = Optic.thatCan.get[Zoo, Tiger](_.tiger)
+  val animalPhoto = Optic.thatCan.get[Animal, Photo](Photo.apply)
+  val tigerPhoto = Optic.thatCan.get[Tiger, Photo](Photo.apply)
+
+
+
   case class Company(name: String)
   case class Pen(color: String, manufacturer: Option[Company] = None)
   case class Office(desk: Desk, pens: List[Pen])

--- a/src/test/scala/monocle/NewOpticsTest.scala
+++ b/src/test/scala/monocle/NewOpticsTest.scala
@@ -141,4 +141,20 @@ class NewOpticsTest extends munit.FunSuite {
     val office = Office(Desk(5, None), List(Pen("red", Some(Company("Pencorp"))), Pen("green"), Pen("blue")))
     assertEquals(composed.getAll(office), List(Company("Hemingsworth"), Company("Pencorp")))
   }
+
+  test("Get & Modify andThen Get (where the second one accepts wider input than the first one produces as output)") {
+    
+    val zooPhoto = Fixtures.zooTiger.andThen(Fixtures.animalPhoto)
+    val zoo = Zoo(Tiger(stripes = 5))
+
+    assertEquals(zooPhoto.get(zoo), Photo(Tiger(5)))
+  }
+
+  test("Get andThen Get (where the second one accepts wider input than the first one produces as output)") {
+    
+    val zooPhoto = Fixtures.getZooTiger.andThen(Fixtures.animalPhoto)
+    val zoo = Zoo(Tiger(stripes = 7))
+
+    assertEquals(zooPhoto.get(zoo), Photo(Tiger(7)))
+  }
 }


### PR DESCRIPTION
- Regretfully adding new type alias `OpticGet[-S, +A]` to correctly fix up the type for getter optics. 
- `GetOptic.id[A]` returns an identity getter, which decapitates `Modify`/`ReverseGet` when composed with another optic
- The `to` method works now as you would expect, getters "just work"
- You can now do variance-aware compositions like `(a: Optic[Get, Zoo, Tiger]).andThen(b: Optic[Animal, Photo])` 